### PR TITLE
Add ciel-mode

### DIFF
--- a/ciel.el
+++ b/ciel.el
@@ -70,7 +70,19 @@
 
 ;;; Code:
 
-(defun ci (arg)
+(defvar ciel-mode-map nil
+  "Keymap used in ciel-mode.")
+(unless ciel-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c i") 'ciel-ci)
+    (define-key map (kbd "C-c o") 'ciel-co)
+    (setq ciel-mode-map map)))
+
+(defvar ciel-mode-lighter " ci")
+
+;;;###autoload
+(defun ciel-ci (arg)
+  ""
   (interactive "sci: ")
   (let ((%region))
     (cond ((or (string= arg "(") (string= arg ")")) (setq %region (region-paren "(")))
@@ -86,10 +98,10 @@
       (kill-region (car %region) (cadr %region)))
     )
   )
-(global-set-key "\C-ci" 'ci)
 
-;; COpy inside
-(defun co (arg)
+;;;###autoload
+(defun ciel-co (arg)
+  "COpy inside."
   (interactive "sco: ")
   (let ((%region))
     (cond ((or (string= arg "(") (string= arg ")")) (setq %region (region-paren "(")))
@@ -106,7 +118,13 @@
     )
   )
 
-(global-set-key "\C-co" 'co)
+;;;###autoload
+(define-minor-mode ciel-mode
+  "Minor mode for ciel."
+  :lighter ciel-mode-lighter
+  :global t
+  ciel-mode-map
+  :group 'ciel)
 
 (defun region-paren (arg)
   (interactive "s") 


### PR DESCRIPTION
Add global minor-mode  instead of `global-set-key`.

Put this snippet into your `.emacs`(`~/.emacs.d/init.el`) :

``` el
(ciel-mode 1)
```
## Namespace

Symbol names be required to comply with [Emacs Lisp Coding Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html) by MELPA.

Public symbols (functions, variables) should be prefixed `ciel-`, and private/internal (utility) functions should be prefixed `ciel--`.  It just acts like a pseudo-namespace.

You will probably need to rename the function.
For example `move-to-parent-parenthesis` → `ciel--move-to-parent-parenthesis`.

By the way, I like [nameless-mode](https://github.com/Malabarba/Nameless).

<img width="140" alt="2016-08-05 1 31 33" src="https://cloud.githubusercontent.com/assets/822086/17409967/883faa4e-5aac-11e6-9ccf-87ef6f5619a4.png">
## autoload cookie

`;;;###autoload` is called “**autoload cookie**”.  See [GNU Emacs Lisp Reference Manual: Autoload](https://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html).

By this mechanism, users can omit `require`/`load` of packages that were installed by the package manager.
## Description in string

Description string associated with the functions and variables is called “[Doc String](https://www.emacswiki.org/emacs/DocString)”.
