### PR TITLE
fix issue when quote is the last character in the line

### DIFF
--- a/ciel.el
+++ b/ciel.el
@@ -368,7 +368,7 @@
   ;; before use this func call (beggining-of-line)
   (unless (search-forward arg nil t)
     (return-from search-points-of-quote-inline points-of-quote)) ;; couldn't find quotes anymore
-  (cond ((< (point) line-end-init)
+  (cond ((<= (point) line-end-init)
 	 (search-points-of-quote-inline (append points-of-quote (list (point))) line-end-init))
 	(t
 	 points-of-quote)))


### PR DESCRIPTION
The original code missed a '=' in the condition, as a result if the quote is the last character of a line, its position could not be appended into points-of-quote then failed with the message like 

'Couldn’t find matching quotes: "\""' 